### PR TITLE
[chore] bump velocity and runvelocity version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = io.github.4drian3d
-version = 1.1.2-SNAPSHOT
+version = 1.1.1-SNAPSHOT
 description = Manage packets through Velocity native events

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = io.github.4drian3d
-version = 1.1.1-SNAPSHOT
+version = 1.1.2-SNAPSHOT
 description = Manage packets through Velocity native events

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,11 @@ metadata.format.version = "1.1"
 [versions]
 
 # CompileOnly dependencies
-velocity = "3.2.0-SNAPSHOT"
+velocity = "3.3.0-SNAPSHOT"
 # Gradle Plugins
 blossom = "1.3.1"
 shadow = "8.1.1"
-runvelocity = "2.2.2"
+runvelocity = "2.2.3"
 
 netty = "4.1.107.Final"
 


### PR DESCRIPTION
VPacketEvents still has Velocity 3.2.0-SNAPSHOT as transient dependency, causing build failure if you depend on VPacketEvents without having velocity-proxy 3.2.0-SNAPSHOT in your local repo.